### PR TITLE
Fix tools/run_integration.sh script

### DIFF
--- a/kostyor/tests/unit/resources/test_discover.py
+++ b/kostyor/tests/unit/resources/test_discover.py
@@ -164,7 +164,7 @@ class TestCreateCluster(oslotest.base.BaseTestCase):
         ]
 
         def _create_host(hostname, _):
-            return filter(lambda h: h['hostname'] == hostname, hosts)[0]
+            return list(filter(lambda h: h['hostname'] == hostname, hosts))[0]
         create_host.side_effect = _create_host
 
         cluster = discover._create_cluster(

--- a/tools/run_integration.sh
+++ b/tools/run_integration.sh
@@ -42,7 +42,7 @@ kostyor cluster-status $CLUSTER_ID
 
 kostyor list-upgrade-versions
 
-kostyor list-discovery-methods
+kostyor discover-list
 
 kostyor check-upgrade $CLUSTER_ID
 


### PR DESCRIPTION
Not so long ago we have merged a patch into Kostyor-cli [1] that slightly
changes discovery commands. Unfortunately, we have forgot to update
those commands in 'tools/run_integration.sh'. This commit updates the
command and unblock test passing on CI.

[1] https://github.com/Mirantis/Kostyor-cli/commit/fddf9e86c756b207989a00083315f255c5ae6c07