### PR TITLE
Rethink upgrade driver interface

### DIFF
--- a/kostyor/upgrades/drivers/base.py
+++ b/kostyor/upgrades/drivers/base.py
@@ -7,132 +7,18 @@ from kostyor.rpc import tasks
 @six.add_metaclass(abc.ABCMeta)
 class UpgradeDriver():
 
-    @abc.abstractproperty
-    def supports_upgrade_rollback(self):
-        """Property used to indicate if an implementation supports rolling back
-        an upgrade
-        """
-        pass
+    def pre_upgrade(self):
+        """Get tasks to be executed before main upgrade procedure.
 
-    def pre_upgrade_hook(self, upgrade_task):
-        """Called by the decision engine before upgrade procedure is started,
-        allows an UpgradeDriver the opportunity to do any operations required
-        before starting other playbooks.
-
-        :param upgrade_task: the upgrade task that the engine is performing
-        :type upgrade_task: kostyor.db.models.UpgradeTask instance
-        """
-        return tasks.noop.si()
-
-    def pre_host_upgrade_hook(self, upgrade_task, host):
-        """Called by the decision engine before a host is upgraded,
-        allows an UpgradeDriver the opportunity to do any operations required
-        before the host is upgraded
-
-        :param host: a host that is scheduled to be upgraded
-        :type host: a kostyor.db.models.Host instance as a dict
-
-        :param upgrade_task: the upgrade task that the engine is performing
-        :type upgrade_task: kostyor.db.models.UpgradeTask instance
-        """
-        return tasks.noop.si()
-
-    def pre_service_upgrade_hook(self, upgrade_task, service):
-        """Called by the decision engine before a service is upgraded,
-        allows an UpgradeDriver the opportunity to do any operations required
-        before a service is upgraded
-
-        :param service: a service that is scheduled to be upgraded
-        :type service: a kostyor.db.models.Service instance as a dict
-
-        :param upgrade_task: the upgrade task that the engine is performing
-        :type upgrade_task: kostyor.db.models.UpgradeTask instance
-        """
-        return tasks.noop.si()
-
-    def post_host_upgrade_hook(self, upgrade_task, host):
-        """Called by the decision engine after a host is upgraded,
-        allows an UpgradeDriver the opportunity to do any operations required
-        after the host is upgraded
-
-        :param host: a host that is scheduled to be upgraded
-        :type host: a kostyor.db.models.Service instance as a dict
-
-        :param upgrade_task: the upgrade task that the engine is performing
-        :type upgrade_task: kostyor.db.models.UpgradeTask instance
-        """
-        return tasks.noop.si()
-
-    def post_service_upgrade_hook(self, upgrade_task, service):
-        """Called by the decision engine after a service is upgraded,
-        allows an UpgradeDriver the opportunity to do any operations required
-        after a service is upgraded
-
-        :param service: a service that is scheduled to be upgraded
-        :type service: a kostyor.db.models.Service instance as a dict
-
-        :param upgrade_task: the upgrade task that the engine is performing
-        :type upgrade_task: kostyor.db.models.UpgradeTask instance
+        :returns: a celery signature
         """
         return tasks.noop.si()
 
     @abc.abstractmethod
-    def cancel_upgrade(self, upgrade_task, service):
-        """Called by the decision engine to cancel an upgrade that is in
-        progress
+    def start(self, service, hosts):
+        """Get tasks to upgrade a given service on a give hosts.
 
-        :param service: a service that is scheduled to be upgraded
-        :type service: a kostyor.db.models.Service instance as a dict
-
-        :param upgrade_task: the upgrade task that the engine is performing
-        :type upgrade_task: kostyor.db.models.UpgradeTask instance
+        :param service: a service to be upgraded
+        :param hosts: a list of hosts to run upgrade on
+        :returns: a celery signature
         """
-        pass
-
-    @abc.abstractmethod
-    def rollback_upgrade(self, upgrade_task, service):
-        """Called by the decision engine to rollback a running upgrade
-
-        :param service: a service that is scheduled to be upgraded
-        :type service: a kostyor.db.models.Service instance as a dict
-
-        :param upgrade_task: the upgrade task that the engine is performing
-        :type upgrade_task: kostyor.db.models.UpgradeTask instance
-        """
-        pass
-
-    @abc.abstractmethod
-    def start_upgrade(self, upgrade_task, service):
-        """Called by the decision engine to start an upgrade
-
-        :param service: a service that is scheduled to be upgraded
-        :type service: a kostyor.db.models.Service instance as a dict
-
-        :param upgrade_task: the upgrade task that the engine is performing
-        :type upgrade_task: kostyor.db.models.UpgradeTask instance
-        """
-        pass
-
-    @abc.abstractmethod
-    def stop_upgrade(self, upgrade_task, service):
-        """Called by the decision engine to stop a running upgrade
-
-        :param service: a service that is scheduled to be upgraded
-        :type service: a kostyor.db.models.Service instance as a dict
-
-        :param upgrade_task: the upgrade task that the engine is performing
-        :type upgrade_task: kostyor.db.models.UpgradeTask instance
-        """
-        pass
-
-    @abc.abstractmethod
-    def pause_upgrade(self, upgrade_task, service):
-        """Called by the decision engine to pause a running upgrade
-
-        :param service: a service that is scheduled to be upgraded
-        :type service: a kostyor.db.models.Service instance as a dict
-
-        :param upgrade_task: the upgrade task that the engine is performing
-        :type upgrade_task: kostyor.db.models.UpgradeTask instance
-        """
-        pass

--- a/kostyor/upgrades/drivers/noop.py
+++ b/kostyor/upgrades/drivers/noop.py
@@ -2,25 +2,7 @@ from kostyor.upgrades.drivers import base
 from kostyor.rpc import tasks
 
 
-class NoOpDriver(base.UpgradeDriver):
+class NoopDriver(base.UpgradeDriver):
 
-    def stop_upgrade(self, upgrade_task, service):
+    def start(self, service, hosts):
         return tasks.noop.si()
-
-    def start_upgrade(self, upgrade_task, service):
-        return tasks.noop.si()
-
-    def pause_upgrade(self, upgrade_task, service):
-        return tasks.noop.si()
-
-    def cancel_upgrade(self, upgrade_task, service):
-        return tasks.noop.si()
-
-    def rollback_upgrade(self, upgrade_task, service):
-        return tasks.noop.si()
-
-    def continue_upgrade(self, upgrade_task, service):
-        return tasks.noop.si()
-
-    def supports_upgrade_rollback(self):
-        return False

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ warnerrors = true
 
 [entry_points]
 kostyor.upgrades.drivers =
-    noop = kostyor.upgrades.drivers.noop:NoOpDriver
+    noop = kostyor.upgrades.drivers.noop:NoopDriver
 
 kostyor.discovery_drivers =
     openstack = kostyor.inventory.discover:OpenStackServiceDiscovery


### PR DESCRIPTION
Working on new upgrade engine, it was turned out that current driver
interface is closely tied to node-by-node approach. If we want to have
single driver interface for various engines it needs to be redesigned,
otherwise we will end up with having different interfaces for different
engine.

In this patch we change driver interface and get rid of a lot of its
methods (as we don't know yet which signature they are going to have).
We only have experience with running upgrades and here we are sure,
it ought to be:

  start(self, service, hosts)

where:

  * `service` - a service to be upgraded
  * `hosts` - a list of hosts to run upgrade on

With new approach we are focused on upgrading services no matter which
hosts they are running.