### PR TITLE
Propagate parameters to upgrade driver

### DIFF
--- a/kostyor/resources/upgrades.py
+++ b/kostyor/resources/upgrades.py
@@ -30,10 +30,22 @@ _SUPPORTED_DRIVERS = stevedore.extension.ExtensionManager(
 class Upgrades(Resource):
 
     _schema = {
-        'cluster_id': {'type': 'string', 'required': True},
-        'to_version': {'type': 'string', 'required': True,
-                       'allowed': constants.OPENSTACK_VERSIONS},
-        'driver': {'type': 'string', 'allowed': _SUPPORTED_DRIVERS.names()},
+        'cluster_id': {
+            'type': 'string',
+            'required': True,
+        },
+        'to_version': {
+            'type': 'string',
+            'required': True,
+            'allowed': constants.OPENSTACK_VERSIONS,
+        },
+        'driver': {
+            'type': 'string',
+            'allowed': _SUPPORTED_DRIVERS.names(),
+        },
+        'parameters': {
+            'type': 'dict',
+        },
     }
 
     @marshal_with(_PUBLIC_ATTRIBUTES)
@@ -57,10 +69,10 @@ class Upgrades(Resource):
                 payload['to_version']
             )
 
-            # TODO: Driver must become requires argument once CLI forces
-            #       users to choose one.
             driver_name = payload.get('driver', 'noop')
-            driver = _SUPPORTED_DRIVERS[driver_name].plugin()
+            driver = _SUPPORTED_DRIVERS[driver_name].plugin(
+                parameters=payload.get('parameters', {}),
+            )
 
             engine = engines.NodeByNode(upgrade, driver)
             engine.start()

--- a/kostyor/upgrades/drivers/base.py
+++ b/kostyor/upgrades/drivers/base.py
@@ -7,6 +7,9 @@ from kostyor.rpc import tasks
 @six.add_metaclass(abc.ABCMeta)
 class UpgradeDriver():
 
+    def __init__(self, parameters=None):
+        self.parameters = parameters or {}
+
     def pre_upgrade(self):
         """Get tasks to be executed before main upgrade procedure.
 


### PR DESCRIPTION
So far there's no way to propagate any parameters to upgrade drivers
from API (or CLI), that's why such drivers as kostyor-openstack-ansible
requires to hardcode path to OpenStack Ansible root.

This commit implements an ability to pass additional key-value
parameters received in API call to upgrade driver __init__ method, so it
will be accessible later by driver implementations.