### PR TITLE
Change response format of `/clusters` endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ cover/
 nosetests.xml
 .testrepository
 .venv
+.cache
 
 # Translations
 *.mo

--- a/kostyor/resources/clusters.py
+++ b/kostyor/resources/clusters.py
@@ -19,10 +19,9 @@ _PUBLIC_ATTRIBUTES = {
 
 class Clusters(Resource):
 
-    @marshal_with({'clusters': fields.Nested(_PUBLIC_ATTRIBUTES)})
+    @marshal_with(_PUBLIC_ATTRIBUTES)
     def get(self):
-        # TODO: get rid of intermediate 'clusters' attribute
-        return {'clusters': db_api.get_clusters()}
+        return db_api.get_clusters()
 
 
 class Cluster(Resource):

--- a/kostyor/tests/unit/resources/test_clusters.py
+++ b/kostyor/tests/unit/resources/test_clusters.py
@@ -34,7 +34,7 @@ class TestClustersEndpoint(oslotest.base.BaseTestCase):
         resp = self.app.get('/clusters')
         self.assertEqual(200, resp.status_code)
 
-        received = json.loads(resp.get_data(as_text=True))['clusters']
+        received = json.loads(resp.get_data(as_text=True))
         self.assertEqual(expected, received)
 
     @mock.patch('kostyor.db.api.get_cluster')


### PR DESCRIPTION
Kostyor's API endpoints `/clusters` is used to respond with the
following JSON:

    {
        "clusters": [
            { ... },
            { ... },
            { ... }
        ]
    }

This format contains a redundant key `clusters`, as it does not carry
any sense. This commit removes the intermediate `clusters` key so the
output looks like:

    [
        { ... },
        { ... },
        { ... }
    ]

Fixes #73