### PR TITLE
Make upgrade engines pluggable

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,10 @@ warnerrors = true
 
 
 [entry_points]
+kostyor.engines =
+    node-by-node = kostyor.upgrades.engines.nodebynode:NodeByNode
+    service-by-service = kostyor.upgrades.engines.servicebyservice:ServiceByService
+
 kostyor.upgrades.drivers =
     noop = kostyor.upgrades.drivers.noop:NoopDriver
 


### PR DESCRIPTION
Similar to discovery and upgrade drivers, let's make upgrade engines
pluggable and discoverable via `kostyor.engines` namespace. It might
be very useful to those who are interested in having custom
orchestration behaviour.

In order to choose a concrete engine you want to use for upgrade one
needs to pass an `engine` parameter in JSON payload:

    POST /upgrades HTTP/1.1

    {
        "engine": "node-by-node",
        "driver": "openstack-ansible",
        "parameters": {
            "root": "..."
        }
    }